### PR TITLE
Add required packages to ansible/bastion/site.yaml

### DIFF
--- a/ansible/bastion/site.yaml
+++ b/ansible/bastion/site.yaml
@@ -71,6 +71,9 @@
     loop:
     - libselinux-python
     - python-passlib
+    - git
+    - epel-release
+    - python-pip
     become: yes
 
   # Add files...


### PR DESCRIPTION
I'm trying to do a "bare metal" install on VMs using the CentOS 7 GenericCloud disk images and I found some packages that I had to install by hand.